### PR TITLE
typo: `Celsius`

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,12 +9,12 @@
   <body>
     <h1>Temperature Converter</h1>
     <div class="form-group col-md-3">
-      <label for="usr">Celcius:</label>
-      <input type="text" class="form-control" id="celcius" onkeyup="celciusToFahrenheit()">
+      <label for="usr">Celsius:</label>
+      <input type="text" class="form-control" id="celsius" onkeyup="celsiusToFahrenheit()">
     </div>
     <div class="form-group col-md-3">
       <label for="pwd">Fahrenheit:</label>
-      <input type="text" class="form-control" id="fahrenheit" onkeyup="fahrenheitToCelcius()">
+      <input type="text" class="form-control" id="fahrenheit" onkeyup="fahrenheitToCelsius()">
     </div>
     <script src='./renderer.js'></script>
   </body>


### PR DESCRIPTION
`Celsius` was misspelled as `Celcius`